### PR TITLE
Only show password validation on signup page and not on login page

### DIFF
--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -236,6 +236,8 @@ function Login() {
                   onChange={(e) => setPassword(e.target.value)}
                   className="w-full pl-10 pr-4 py-3 rounded-lg bg-white/80 focus:outline-none focus:ring-2 focus:ring-pink-300"
                 />
+                {!isLogin && (
+                  <>
                 <PasswordStrengthBar password={password} />
                 <div>
                   <ValidIndicator
@@ -259,6 +261,8 @@ function Login() {
                     text={"Minimum length of 8 characters"}
                   />
                 </div>
+                </>
+                )}
               </div>
 
               <button


### PR DESCRIPTION
There is no need for showing the password validation on the login page. So added a simple check for it.


I couldn't test it locally because of firebase errors...but this should work