### PR TITLE
Fixes #59 [feat] Added show/hide password toggle in input field

### DIFF
--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import PasswordStrengthBar from "react-password-strength-bar";
-import { Check, X } from "lucide-react";
+import { Check, Eye, EyeOff, X } from "lucide-react";
 import { useLocation } from "react-router-dom";
 import {
   getAuth,
@@ -24,6 +24,7 @@ function Login() {
   const [password, setPassword] = useState("");
   const [email, setEmail] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const location = useLocation();
   const params = new URLSearchParams(location.search);
   const redirectPath = params.get("redirect") || "/";
@@ -162,6 +163,10 @@ function Login() {
     setIsLogin(!isLogin);
   };
 
+  const toggleShowPassword = () =>{
+    setShowPassword(!showPassword)
+  };
+
   return (
     <div className="min-h-screen w-full flex items-center justify-center bg-transparent">
       <div className="bg-[#ffdad7] p-8 md:p-12 rounded-xl shadow-2xl mx-5 md:mx-0 flex flex-col justify-between max-w-md w-full">
@@ -248,12 +253,21 @@ function Login() {
                   size={18}
                 />
                 <input
-                  type="password"
+                  type={showPassword ? "text" : "password"}
                   placeholder="Password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full pl-10 pr-4 py-3 rounded-lg bg-white/80 focus:outline-none focus:ring-2 focus:ring-pink-300"
+                  className="w-full pl-10 pr-12 py-3 rounded-lg bg-white/80 focus:outline-none focus:ring-2 focus:ring-pink-300"
                 />
+                {!showPassword?<Eye 
+                  className="absolute right-4 top-3 text-gray-400 cursor-pointer"
+                  onClick={toggleShowPassword}
+                />:
+                <EyeOff 
+                  className="absolute right-4 top-3 text-gray-400 cursor-pointer"
+                  onClick={toggleShowPassword}
+                />}
+                
                 {!isLogin && (
                   <>
                 <PasswordStrengthBar password={password} />


### PR DESCRIPTION
<!--- 
Thank you for contributing to DateNow!  
Please fill out the sections below so we can review faster.
-->

## 🔗 Related Issue  
<!--- Use the keyword `resolves` so the issue is auto-closed when merged -->
Resolves #59

---

## 📖 Description  
Added an eye icon which shows password when click and vice versa

---

## 🛠️ Key Changes  
-Added showPassword State
-Added togglePassword function
-Added eye icon which toggles on click
-Changed padding for input box for the password
-Changes type of input by the ternary operator which defines the type of input box from either text or password

---

## 🎥 Demo Video / Screenshots (if applicable)  

https://github.com/user-attachments/assets/baa51e6d-65c1-4c9f-9e05-e29deb2d2ca0



---

## ✅ Checklist  
- [✅  ] Code follows the style guidelines of this project  
- [✅  ] I have tested my changes locally  
- [ ] Documentation has been updated (if needed)  
- [✅ ] Linked the related issue using `resolves #ISSUE_NUMBER`  
