### PR TITLE
 Updates the date display format

### DIFF
--- a/src/components/profile/Profile.jsx
+++ b/src/components/profile/Profile.jsx
@@ -26,7 +26,7 @@ export default function DateNowProfile() {
     if (user) { 
       const date = new Date(Number(user.metadata.createdAt)); 
       console.log(user); 
-      const formatted = date.toLocaleDateString("en-US",{ weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }); 
+      const formatted = date.toLocaleDateString("en-US",{ year: 'numeric', month: 'long', day: 'numeric' }); 
       setName(user.displayName); 
       setEmail(user.email); 
       setJoinDate(formatted); 

--- a/src/components/profile/Profile.jsx
+++ b/src/components/profile/Profile.jsx
@@ -26,7 +26,7 @@ export default function DateNowProfile() {
     if (user) { 
       const date = new Date(Number(user.metadata.createdAt)); 
       console.log(user); 
-      const formatted = date.toLocaleDateString("en-GB", { day: "2-digit", month: "short", year: "numeric", }); 
+      const formatted = date.toLocaleDateString("en-US",{ weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }); 
       setName(user.displayName); 
       setEmail(user.email); 
       setJoinDate(formatted); 


### PR DESCRIPTION
## 🔗 Related Issue  
Resolves #50 

---

## 📖 Description  
This PR updates the date display format in Profile.jsx from short numeric format to full human readable format: Saturday, October 4, 2025

---

## 🎥 Demo Video / Screenshots (if applicable)  
<img width="1810" height="818" alt="Screenshot 2025-10-04 165730" src="https://github.com/user-attachments/assets/218bb47c-df76-4ecf-b9bd-69314339ac46" />


---

## ✅ Checklist  
- [ ] Code follows the style guidelines of this project  
- [ ] I have tested my changes locally  
- [ ] Documentation has been updated (if needed)  
- [ ] Linked the related issue using `resolves #50 `  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Enhancements
  - Updated profile join date display to US English formatting (month spelled out, numeric day and year, e.g., January 15, 2024). Other profile fields (name, email, image) unchanged.

- Chores
  - No changes to public interfaces or exported signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->