### PR TITLE
Add GitHub Action to re-request review on PR update

### DIFF
--- a/.github/workflows/re-request-on-update.yml
+++ b/.github/workflows/re-request-on-update.yml
@@ -1,0 +1,17 @@
+name: Re-request Code Owner Review on PR Update
+
+on:
+  pull_request:
+    types: [synchronize]
+
+jobs:
+  re-request-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Re-request review from code owners
+        uses: peter-evans/re-request-review@v2
+        with:
+          reviewers: 'codeowners'
+          wait-for-mergeable: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/re-request-on-update.yml
+++ b/.github/workflows/re-request-on-update.yml
@@ -1,7 +1,7 @@
 name: Re-request Code Owner Review on PR Update
 
 on:
-  pull_request:
+  pull_request_target:
     types: [synchronize]
 
 # Grant the action explicit permissions to write to pull requests

--- a/.github/workflows/re-request-on-update.yml
+++ b/.github/workflows/re-request-on-update.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [synchronize]
 
+# Grant the action explicit permissions to write to pull requests
+permissions:
+  pull-requests: write
+  contents: read
+
+
 jobs:
   re-request-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 🔗 Related Issue  
Resolves #93  
---

## 📖 Description  
- Adds workflow to automatically re-request code owner reviews when a PR receives new commits.
- Trigger: pull request synchronize event
- Only requests review from CODEOWNERS

---

## ✅ Checklist  
- [x] Code follows the style guidelines of this project  
- [x] I have tested my changes locally  
- [x] Documentation has been updated (if needed)  
- [x] Linked the related issue using `resolves #ISSUE_NUMBER`  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Added automation to automatically re-request code owner reviews when a pull request is updated.
  * Ensures reviewers are notified after changes and waits until the pull request is mergeable before re-requesting.
  * Uses repository authorization to perform requests safely.
  * Reduces manual follow-ups and helps keep review status aligned with the latest updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->