### PR TITLE
Improved Error Handling

### DIFF
--- a/src/components/login/Login.jsx
+++ b/src/components/login/Login.jsx
@@ -156,7 +156,13 @@ function Login() {
       });
       navigate(redirectPath);
     } catch (error) {
-      setErrorMessage(error.message);
+      if (error.code === 'auth/popup-closed-by-user') {
+        setErrorMessage('User closed the sign-in popup.')
+        return;
+      }
+      else{
+        setErrorMessage(error.message);
+      }
     }
   };
 


### PR DESCRIPTION
<!--- 
Thank you for contributing to DateNow!  
Please fill out the sections below so we can review faster.
-->

## 🔗 Related Issue  
<!--- Use the keyword `resolves` so the issue is auto-closed when merged -->
Resolves #109 

---

## 📖 Description  
<!--- Clearly describe what your PR does -->
This PR improves the Google Sign-In error handling for cases where the user manually closes the authentication popup before completing the process.

Previously, Firebase displayed a raw technical message:
`Firebase: Error (auth/popup-closed-by-user)`
Now, the app shows a more user-friendly message —
`User closed the sign-in popup.`
This provides a cleaner and more intuitive experience for users.

---

## 🛠️ Key Changes  
- Added specific error handling for auth/popup-closed-by-user in the authentication flow.
- Replaced the Firebase developer message with a user-friendly one.
- Improved UX consistency by preventing unnecessary error banners.

---

## 💡 Additional Note

If needed, I can extend this approach and add more specific error handling messages for other Firebase authentication errors (e.g., network failure, account-exists, popup-blocked, etc.) to further improve user experience.

---

## 🎥 Demo Video / Screenshots (if applicable)  
<!--- Attach screenshots or a short demo video showing your changes -->
<img width="1335" height="647" alt="image" src="https://github.com/user-attachments/assets/5e38f7cc-68db-4346-b1ba-eed11e9a3670" />

---

## ✅ Checklist  
- [x] Code follows the style guidelines of this project  
- [x] I have tested my changes locally  
- [ ] Documentation has been updated (if needed)  
- [x] Linked the related issue using `resolves #ISSUE_NUMBER`  
